### PR TITLE
Obtener export id del csv de contactos

### DIFF
--- a/models/user_client.py
+++ b/models/user_client.py
@@ -158,21 +158,14 @@ class user_client(models.Model):
     # nacionalidad
     nacionalidad = fields.Char("Nacionalidad")
 
-    # id externo
-    external_id = fields.Char(compute='_external_id', store=True)
-
-    def _external_id(self):
-        res = self.get_external_id()
-        if 7 in res:
-            self.res_id = res[7][1:]
-        else:
-            self.res_id = ""
+    # id externo en tabla de res_partner
+    client_export_id = fields.Char("Export ID")
 
     # exportación sae
     @api.multi
     def export(self):
         columns = [
-            'external_id',
+            'client_export_id',
             'name',
             'rfc',
             'street',

--- a/models/user_sales_order.py
+++ b/models/user_sales_order.py
@@ -91,7 +91,7 @@ class user_sales_order(models.Model):
     # renovacion de suscripción automatica
     auto_sub = fields.Boolean("Automatic Subscription Renewal")
 
-    # zona derivada de dirección
+    # zona derivada de contacto
     related_partner_zone = fields.Selection(
         string="Zone",
         related="partner_id.zone",
@@ -105,6 +105,22 @@ class user_sales_order(models.Model):
         for record in self:
             if record.related_partner_zone:
                 record.partner_zone = record.related_partner_zone.upper()
+
+    # id derivado de contacto
+    related_partner_export_id = fields.Char(
+        string="Partner ID",
+        related="partner_id.client_export_id",
+        readonly=True,
+        company_dependent=True)
+
+    partner_export_id = fields.Char(
+        "Export ID", compute="_get_export_id", store=True)
+
+    @api.depends("related_partner_export_id")
+    def _get_export_id(self):
+        for record in self:
+            if record.related_partner_export_id:
+                record.partner_export_id = record.related_partner_export_id
 
     # direccion de factura
     invoice_address_id = fields.Many2one("res.partner", string="Sale Address")
@@ -198,7 +214,7 @@ class user_sales_order(models.Model):
     def export(self):
         columns = [
             "id",
-            "partner_id",
+            "partner_export_id",
             "date_order",
             "note",
             "delivery_date",


### PR DESCRIPTION
El External ID se guarda en otra tabla y no se actualiza en todos los casos. En vez acceder de esta manera, se debe agregar una columna titulada `client_export_id` con el mismo valor que `id`. Ya teniendo la referencia en la misma tabla es fácil exportar y relacionarla.